### PR TITLE
Dismiss dialog after user hits "NO" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,3 @@ coverage/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
-/.flutter-plugins-dependencies

--- a/lib/config/app_router.dart
+++ b/lib/config/app_router.dart
@@ -2,6 +2,7 @@ import 'package:fluro/fluro.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:gmoh_app/ui/pages/action_selection_page.dart';
 import 'package:gmoh_app/ui/pages/locator/alt_location_page.dart';
+import 'package:gmoh_app/ui/pages/locator/current_user_location.dart';
 import 'package:gmoh_app/ui/pages/locator/home_locator_page.dart';
 import 'package:gmoh_app/ui/pages/ride_party_page.dart';
 import 'package:gmoh_app/ui/pages/trip_confirmation_map.dart';
@@ -18,12 +19,14 @@ class AppRouter {
 
   static Handler _alternateLocationPageHandler =
       Handler(handlerFunc: (BuildContext context, Map<String, dynamic> params) {
-    return AlternateLocationPage();
+        var position = (params['position']);
+        return AlternateLocationPage(position);
   });
 
   static Handler _homeLocatorPageHandler =
       Handler(handlerFunc: (BuildContext context, Map<String, dynamic> params) {
-    return HomeLocatorPage();
+        var position = (params['position']);
+        return HomeLocatorPage(position);
   });
 
   static Handler _mapPageHandler =
@@ -33,11 +36,18 @@ class AppRouter {
     return TripConfirmationMap(double.parse(latitude), double.parse(longitude));
   });
 
+  static Handler _currentUserLocationPageHandler =
+  Handler(handlerFunc: (BuildContext context, Map<String, dynamic> params) {
+    var position = (params['position']);
+    return CurrentUserLocationPage(position);
+  });
+
   static void setupRouter() {
     router.define('action_selection', handler: _actionSelectionHandler);
     router.define('ride_party_page', handler: _ridePartyPageHandler);
-    router.define('alt_location_page', handler: _alternateLocationPageHandler);
-    router.define('home_locator_page', handler: _homeLocatorPageHandler);
+    router.define('alt_location_page/:userPosition', handler: _alternateLocationPageHandler);
+    router.define('home_locator_page/:userPosition', handler: _homeLocatorPageHandler);
     router.define('map/:latlng', handler: _mapPageHandler);
+    router.define('current_user_location', handler: _currentUserLocationPageHandler);
   }
 }

--- a/lib/ui/pages/action_selection_view.dart
+++ b/lib/ui/pages/action_selection_view.dart
@@ -1,13 +1,77 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:gmoh_app/io/database/location_database.dart';
 import 'package:gmoh_app/io/models/home_location_result.dart';
-import 'package:gmoh_app/ui/models/locator_page_model.dart';
+import 'package:gmoh_app/io/repository/location_repo.dart';
+import 'package:gmoh_app/ui/blocs/user_locations_bloc.dart';
 import 'package:gmoh_app/util/hex_color.dart';
+import 'package:gmoh_app/util/permissions_helper.dart';
 
-class ActionSelectionView extends StatelessWidget {
+class ActionSelectionView extends StatefulWidget {
   final HomeLocationResult homeLocationResult;
 
   ActionSelectionView(this.homeLocationResult);
+
+  @override
+  _ActionSelectionViewState createState() => _ActionSelectionViewState();
+}
+
+class _ActionSelectionViewState extends State<ActionSelectionView>
+    implements PermissionDialogListener {
+
+  var hasRequestedLocationPermission = false;
+  final permissionsHelper = new PermissionsHelper();
+
+  Position userPosition;
+  UserLocationsBloc _locationBloc;
+
+  @override
+  void initState() {
+    attemptToRetrieveUserPosition();
+    super.initState();
+
+    var locationDatabase = LocationDatabase();
+    _locationBloc = UserLocationsBloc(LocationRepository(locationDatabase));
+  }
+
+  @override
+  void onPermissionDenied() {
+    hasRequestedLocationPermission = true;
+  }
+
+  @override
+  void onRequestPermission() {
+    setState(() {
+      permissionsHelper.requestLocationPermission();
+      hasRequestedLocationPermission = true;
+    });
+  }
+
+  void attemptToRetrieveUserPosition() async {
+    var locationPermissionGranted =
+        await permissionsHelper.isLocationPermissionGranted();
+    if (!locationPermissionGranted && !hasRequestedLocationPermission) {
+      requestLocationPermission();
+      return;
+    } else if (locationPermissionGranted) {
+      Position position = await Geolocator()
+          .getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
+      setState(() {
+        userPosition = position;
+      });
+    }
+  }
+
+  void requestLocationPermission() async {
+    if (await permissionsHelper.requestLocationPermission()) {
+      setState(() {
+        hasRequestedLocationPermission = true;
+      });
+    } else {
+      permissionsHelper.onLocationPermissionDenied(context, this);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +87,10 @@ class ActionSelectionView extends StatelessWidget {
         children: <Widget>[
           Container(
             margin: EdgeInsets.only(top: 72.0, right: 24.0, left: 24.0),
-            decoration: BoxDecoration(borderRadius: BorderRadius.circular(10),color: HexColor("#078B91"),),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              color: HexColor("#078B91"),
+            ),
             child: SizedBox(
               width: double.infinity,
               height: 120,
@@ -32,11 +99,13 @@ class ActionSelectionView extends StatelessWidget {
                 child: FittedBox(
                   fit: BoxFit.scaleDown,
                   child: SizedBox(
-                    child: Text('Where are you going?',
-                        style: TextStyle(color: Colors.white,
-                            fontSize: 24,
-                            fontFamily: 'Montserrat',
-                            fontWeight: FontWeight.w400),
+                    child: Text(
+                      'Where are you going?',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 24,
+                          fontFamily: 'Montserrat',
+                          fontWeight: FontWeight.w400),
                     ),
                   ),
                 ),
@@ -72,15 +141,16 @@ class ActionSelectionView extends StatelessWidget {
                 textColor: Colors.white,
                 elevation: 4,
                 onPressed: () {
-                  if (homeLocationResult is HomeLocationSet) {
-                    final noticeText = new Text(
-                        "Location: Lat=${(homeLocationResult as HomeLocationSet).location.latitude} Lng=${(homeLocationResult as HomeLocationSet).location.longitude}");
-                    Scaffold.of(context).showSnackBar(new SnackBar(
-                      content: noticeText,
-                    ));
-                  } else if (homeLocationResult is HomeLocationNotSet) {
-                    Navigator.pushNamed(context,
-                        'home_locator_page/${getStringFromEnum(HomeLocationPageMode.HOME_LOCATION)}');
+
+                  if (widget.homeLocationResult is HomeLocationSet) {
+                    // take user to trip map page
+//                    final noticeText = new Text(
+//                        "Location: Lat=${(widget.homeLocationResult as HomeLocationSet).location.latitude} Lng=${(widget.homeLocationResult as HomeLocationSet).location.longitude}");
+//                    Scaffold.of(context).showSnackBar(new SnackBar(
+//                      content: noticeText,
+//                    ));
+                  } else if (widget.homeLocationResult is HomeLocationNotSet) {
+                    Navigator.pushNamed(context, 'home_locator_page/$userPosition');
                   }
                 },
               ),
@@ -110,7 +180,7 @@ class ActionSelectionView extends StatelessWidget {
                 textColor: Colors.white,
                 elevation: 4,
                 onPressed: () {
-                  Navigator.pushNamed(context, 'alt_location_page');
+                  Navigator.pushNamed(context, 'alt_location_page/:$userPosition');
                 },
               ),
             ),

--- a/lib/ui/pages/locator/alt_location_page.dart
+++ b/lib/ui/pages/locator/alt_location_page.dart
@@ -1,21 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:gmoh_app/ui/pages/locator/locator_page.dart';
 
 class AlternateLocationPage extends LocatorPage {
   static const String routeName = "/altLocationPage";
+  final Position position;
 
-  AlternateLocationPage();
+  AlternateLocationPage(this.position) : super(position);
 
   @override
-  LocatorPageState createState() => AlternateLocationState();
+  LocatorPageState createState() => AlternateLocationState(position);
 }
 
 class AlternateLocationState extends LocatorPageState {
-  AlternateLocationState() : super();
+  AlternateLocationState(position) : super(position);
 
   @override
   String getHintText() {
-    return "Enter your destination address here...";
+    return "Enter your destination address here";
   }
 
   @override
@@ -26,5 +28,15 @@ class AlternateLocationState extends LocatorPageState {
   @override
   String getContinueButtonText() {
     return "Set Address and Go";
+  }
+
+  @override
+  void navigateToNextPage() {
+    //navigate to trip map page
+    if (useEnteredAddress().isNotEmpty) {
+      var enteredAddress = useEnteredAddress();
+      // navigate to trip map page
+      //Navigator.pushNamed(context, 'alt_location_page');
+    }
   }
 }

--- a/lib/ui/pages/locator/current_user_location.dart
+++ b/lib/ui/pages/locator/current_user_location.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:gmoh_app/ui/pages/locator/locator_page.dart';
+
+class CurrentUserLocationPage extends LocatorPage {
+  static const String routeName = "/currentUserLocationPage";
+  final Position position;
+
+  CurrentUserLocationPage(this.position) : super(position);
+
+  @override
+  LocatorPageState createState() => _CurrentUserLocationState(position);
+}
+
+class _CurrentUserLocationState extends LocatorPageState {
+  _CurrentUserLocationState(position) : super(position);
+
+  @override
+  String getHintText() {
+    return "Enter your current location's address";
+  }
+
+  @override
+  String getAppBarTitle() {
+    return "What is Your Current Location?";
+  }
+
+  @override
+  String getContinueButtonText() {
+    return "Set as Current Location";
+  }
+
+  @override
+  void navigateToNextPage() {
+    //navigate back to action selection page
+    if (useEnteredAddress().isNotEmpty) {
+      var enteredAddress = useEnteredAddress();
+      Navigator.pop(context, 'action_selection/$enteredAddress');
+    }
+  }
+}

--- a/lib/ui/pages/locator/home_locator_page.dart
+++ b/lib/ui/pages/locator/home_locator_page.dart
@@ -1,21 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:gmoh_app/ui/blocs/user_locations_bloc.dart';
 import 'package:gmoh_app/ui/pages/locator/locator_page.dart';
 
 class HomeLocatorPage extends LocatorPage {
   static const String routeName = "/homeLocatorPage";
+  final Position position;
 
-  HomeLocatorPage();
+  HomeLocatorPage(this.position) : super(position);
 
   @override
-  LocatorPageState createState() => _HomeLocatorState();
+  LocatorPageState createState() => _HomeLocatorState(position);
 }
 
 class _HomeLocatorState extends LocatorPageState {
-  _HomeLocatorState() : super();
+  _HomeLocatorState(Position position) : super(position);
+  UserLocationsBloc _locationBloc;
 
   @override
   String getHintText() {
-    return "Enter your home address here...";
+    return "Enter your home address here";
   }
 
   @override
@@ -26,5 +30,17 @@ class _HomeLocatorState extends LocatorPageState {
   @override
   String getContinueButtonText() {
     return "Set as Home and Go";
+  }
+
+  @override
+  void navigateToNextPage() {
+    // save address as home
+    if (useEnteredAddress().isNotEmpty) {
+      var homeAddress = useEnteredAddress();
+      _locationBloc.setHomeLocation(
+          homeAddress.first, homeAddress.elementAt(1), homeAddress.last);
+        // navigate to trip map page
+        //Navigator.pushNamed(context, 'alt_location_page');
+    }
   }
 }

--- a/lib/util/permissions_helper.dart
+++ b/lib/util/permissions_helper.dart
@@ -23,7 +23,7 @@ class PermissionsHelper {
         barrierDismissible: false,
         builder: (BuildContext context) {
           return AlertDialog(
-            title: Text('Are you sure?'),
+            title: Text('Location Needed'),
             content: const Text(
                 'Location Permission is needed to determine where to pick you up. Do you want to enable it?'),
             actions: <Widget>[
@@ -31,14 +31,13 @@ class PermissionsHelper {
                 child: Text('NO'),
                 onPressed: () {
                   listener.onPermissionDenied();
-                  Navigator.pop(context);
+                  Navigator.popAndPushNamed(context, 'current_user_location');
                 },
               ),
               FlatButton(
                 child: Text('YES'),
                 onPressed: () {
                   listener.onRequestPermission();
-                  Navigator.pop(context);
                 },
               )
             ],


### PR DESCRIPTION
navigated user to view in which they can manually enter their current location
add getting user position to action_selection_view.dart
add passing of address from action_selection_view.dart to home_locator_page.dart and alt_location_page.dart
remove navigation to trip map view by clicking on address suggestion view

**Link to ticket:** https://kanban-chi.appspot.com/dashboard/6686430532993024/d-6686430532993024/c-4523951220588544

![Screenshot_20200729-121808~2 1](https://user-images.githubusercontent.com/7855677/88844923-415bf080-d198-11ea-9308-b2b682ad0add.png)
![Screenshot_20200729-121920~2 1](https://user-images.githubusercontent.com/7855677/88844945-49b42b80-d198-11ea-956e-8786b0f2c84f.png)


**Steps to test**

1. Fresh install the app
2. Notice that a user is prompted to get GPS permission on the first page of the app, this was work done in this PR
3. Deny the app permissions. This will trigger a dialog box to pop asking the user to enable GPS permissions 
4. Within this dialog, hit NO. This will navigate the user to the new page, depicted above, to manually enter their current location's address 
5. Enter address, the pick one. Notice that the address is prepopulated within the search bar. This was work done on this ticket. 
6. With the address in the search bar, the addresses suggestion list should disappear too, along with the keyboard.
7. Hit the button to confirm your current address. This will close the current page and navigate the user back to the homepage to determine where the way to go.  The address entered will be passed back to the homepage. In the next work, the trip map should get the current user's address and the destination address then use both to plot a destination that will be then portrayed on the map.