### PR TITLE
Address Exception in Locator Page

### DIFF
--- a/lib/ui/pages/locator/locator_page.dart
+++ b/lib/ui/pages/locator/locator_page.dart
@@ -150,7 +150,7 @@ abstract class LocatorPageState extends State<LocatorPage> {
                   ),
                 ),
                 Container(
-                    transform: Matrix4.translationValues(0.0, -8.0, 0.0),
+                    transform: Matrix4.translationValues(0.0, -10.0, 0.0),
                     child: searchResult != null
                         ? buildSuggestionList(searchResult)
                         : Container()),


### PR DESCRIPTION
There is an unhandled exception in the Locator Page. Showing up as a broken drop-down suggestion box to address inputs from the user. 

![locator](https://user-images.githubusercontent.com/57809593/93510028-743b7e80-f8d5-11ea-89dc-d7c3c1d225bb.jpg)
